### PR TITLE
Adding sqlscript: 4_create_cetas

### DIFF
--- a/sqlscript/4_create_cetas.json
+++ b/sqlscript/4_create_cetas.json
@@ -1,0 +1,20 @@
+{
+	"name": "4_create_cetas",
+	"properties": {
+		"folder": {
+			"name": "ldw"
+		},
+		"content": {
+			"query": "-- This script is useless because CETAS allows you to run script only once.  \n-- If you need to re-create the external file that was created by the initial CETAS statement, you need to first drop the EXTERNAL TABLE\n-- then manually drop the folder and files from storage, and then re-run\nUSE realtor\nGO\n\nIF EXISTS (\n    SELECT * FROM sys.external_tables\n    WHERE name = 'StageListings2')\n    drop EXTERNAL table StageListings3;\n\nCREATE EXTERNAL TABLE StageListings3\n    WITH (\n        LOCATION = 'stage/',\n        DATA_SOURCE = realtor,\n        FILE_FORMAT = SynapseParquetFormat    \n    )\nAS\nSELECT\nDISTINCT *\nFROM\n    OPENROWSET(\n        BULK '/2023/05/05/*.parquet',\n        DATA_SOURCE = 'realtor_raw',\n        FORMAT = 'PARQUET'\n    )\nAS listings;\n\n\nSELECT COUNT(1) FROM StageListings3;",
+			"metadata": {
+				"language": "sql"
+			},
+			"currentConnection": {
+				"databaseName": "realtor",
+				"poolName": "Built-in"
+			},
+			"resultLimit": 5000
+		},
+		"type": "SqlQuery"
+	}
+}


### PR DESCRIPTION
PR for adding create_cetas.sql script to project. 

Note: This script was not utilized to build any artifacts (external tables, etc.) because CETAS can only be created once so script cannot be re-run unless both external table and the data created by CETAS in storage are dropped. 